### PR TITLE
Update finish.md

### DIFF
--- a/docs/finish.md
+++ b/docs/finish.md
@@ -71,7 +71,6 @@ AWorldOfPainFO3.esm
 AWOP FO3 - TTW Patch.esp
 Rebuild the Capital - A World of Pain for Fallout 3 Patch.esp
 Cyberware.esm
-ISControl.esm
 Brotherhood and House Truce.esm
 Brotherhood and Legion Truce.esm
 Hardin and NCR Truce.esm
@@ -89,7 +88,7 @@ Badmothafucka.esm
 NewVegasKiller.esm
 Simple Open Freeside - TTW + Uncut Wasteland + NVBI LE Patch.esm
 SOF-NVBILE Patch.esm
-Tweaks TTW.esm
+TweaksTTW.esm
 TTW 3.3.2 Hotfix.esp
 The Mod Configuration Menu.esp
 DarNifiedUINV.esp
@@ -136,7 +135,6 @@ SimpleDiseases.esp
 ThreePerkBounty.esp
 Tutorial Killer.esp
 Benny Humbles You and Steals Your Stuff.esp
-Benny Humbles You and Steals Your Stuff - TTW Patch.esp
 AWOPR - Underpass Patch.esp
 ClaimtheMojaveFPGE.esp
 ClaimtheMojaveMojaveRaiders.esp


### PR DESCRIPTION
Loadorder needs a couple of revisions. Here are some of the ones I noticed and changed:
`ISControl.esm` is no longer a thing as ISControl is now ESPless.
`Tweaks TTW.esm` is now `TweaksTTW.esm`
`Benny Humbles You and Steals Your Stuff - TTW Patch.esp` is no longer needed and no longer exists.

Others that I didn't, but noted nontheless:
Whats `Ragdolls TTW Patch.esp`? Load order doesn't have the main mod, and Ragdolls has a TTW compatible version. `InfirmaryOverhaulTTW.esp` is an old name that is no longer relevant for people following the guide. Only useful to ongoing playthroughs that have old name version.
`Metro Ghoul and Tenpenny Residents Truce.esp` seems to be deleted from Nexus?