### PR TITLE
Adding DelayDLCReduxPOPP.esp to the loadorder

### DIFF
--- a/docs/finish.md
+++ b/docs/finish.md
@@ -108,6 +108,7 @@ GRA Scavenger Hunt Unbalanced.esp
 GRA Unique Weapons Relocated - TTW Patch.esp
 Rebuild the Capital - No Pony Express Boxes.esp
 SaveRestrictions.esp
+DelayDLCReduxPOPP.esp
 sawyerbatty.esp
 SawyerBatty TTW - TTW Patch.esp
 SawyerBatty TTW - Uncut Wasteland Patch.esp


### PR DESCRIPTION
I opted to use the optional file Delay DLC Redux - Pre-Order Pack Placement and I inserted its esp on the load order on the same place as sawyerbatty since it does the same thing