### PR TITLE
content.md, MTB, DWD updates

### DIFF
--- a/docs/content.md
+++ b/docs/content.md
@@ -73,6 +73,7 @@ A mobile player home fueled by flamer ammo. This special edition of MTB can even
 - Main File - [Mobile Truck Base SFX Enhancer](https://www.nexusmods.com/newvegas/mods/77110)
 - Main File - [TTW - Mobile Truck Base Megaton Mover](https://www.nexusmods.com/newvegas/mods/77160) (strongly recommended if you plan to use Springvale Garage)
 - Main File - [Mobile Truck Base Sorting Add On - TTW](https://www.sublevel3.com/mmtv/fnv/ttw-mtb-sorting-addon.html)
+  - You should also install the **Compatibility patch for SawyerBatty TTW** if you plan to use [SawyerBatty](overhauls#sawyerbatty) (coming up in the next section). 
 
 ### [Sink Redux](https://www.sublevel3.com/mmtv/fnv/ttw-sink_redux.html)
 
@@ -97,4 +98,4 @@ Adds Skyrim-esque weapon displays. Fully compatible with weapons from all the DL
 - Main File - Dynamic Weapon Displays
   - In the FOMOD installer select any patches for mods you installed, and choose a display model. Do NOT install the Mobile Truck Base patch, that is for the New Vegas version by Qolore.
 - Main File - [Dynamic Weapon Displays - New Vegas Pack - TTW Patch](https://www.nexusmods.com/newvegas/mods/77945)
-- Main File - [Dynamic Weapon Displays - New Vegas Pack - MMTV Sink Redux Patch](https://www.nexusmods.com/newvegas/mods/79005)
+- Main File - [Dynamic Weapon Displays and MMTV Sink Redux Patch](https://www.nexusmods.com/newvegas/mods/79005)

--- a/docs/finish.md
+++ b/docs/finish.md
@@ -96,7 +96,7 @@ MTB Megaton Mover.esp
 PlayerHomeUpgradesTTWReputationsPatch.esp
 DWD-New Vegas Pack.esp
 Dynamic Weapon Displays - New Vegas Pack - TTW Patch.esp
-Dynamic Weapon Displays - New Vegas Pack - MMTV Sink Redux Patch.esp
+Dynamic_Weapon_Displays_-_New_Vegas_Pack_-_MMTV_Sink_Redux_Patch.esp
 DWD - TTW Pack.esp
 DWD-Springville Garage.esp
 Benny Humbles You and Steals Your Stuff.esp
@@ -116,6 +116,7 @@ DelayDLCReduxPOPP.esp
 sawyerbatty.esp
 SawyerBatty TTW - TTW Patch.esp
 SawyerBatty TTW - Uncut Wasteland Patch.esp
+MMTV_MTB_SortingAddon_SawyerBatty_Patch.esp
 RRTV_CW_Hideouts_SawyerBatty_Patch.esp
 RTC-SpringvaleGarageTerminal.esp
 MMTV_SinkRedux_SawyerBatty_Patch.esp


### PR DESCRIPTION
content.md:
- Mobile Truck Base Sorting Add On has now a SawyerBatty patch, I added it right under the mod in question.
- Dynamic Weapon Displays had a name change in a patch, I replaced the text in the anchor with the new name

finish.md:
- Reflected the changes to the .esp of the previous two updates in the loadorder.txt (you should still check if MMTV_MTB_SortingAddon_SawyerBatty_Patch.esp is fine in the order as I guessed its position, while for Dynamic_Weapon_Displays_-_New_Vegas_Pack_-_MMTV_Sink_Redux_Patch.esp I simply replaced the old one with the new one)