### PR TITLE
Loadorder update 11-20-2023

### DIFF
--- a/docs/finish.md
+++ b/docs/finish.md
@@ -66,6 +66,7 @@ RRTV_FO3_CapitalWasteland_Hideouts_TTW.esm
 SpringvaleGarage.esm
 CompletePlayerHomeUpgradesTTW.esm
 Home and Safehouse Tweaks.esm
+Home and Safehouse Tweaks - TTW Addon.esm
 MMTV_Sink_Redux_TTW.esm
 DynamicWeaponDisplays.esm
 Cyberware.esm


### PR DESCRIPTION
Home and Safehouse Tweaks included a patch for TTW, but it isn't included in the loadorder. I added it just under the base .esm, as I was instructed in the TTW Discord.