### PR TITLE
Move High Res Local Maps to UI & HUD section

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -235,6 +235,10 @@ Changes the loading wheel to resemble a vault door, fitting very well within the
 
 Replaces all of the maps with simple vector imagery akin to Fallout 4.
 
+### [High Res Local Maps](https://www.nexusmods.com/newvegas/mods/77963)
+
+Sharper, clearer local maps.
+
 #### Installation:
 
 - Main File - Simple Maps - TTW

--- a/docs/visuals.md
+++ b/docs/visuals.md
@@ -62,10 +62,6 @@ Gives the "Consistent Pip-Boy Icons" treatment to modded content such as Cyberwa
 
 Attaches Pip-Boy light to the Pip-Boy so it moves with the player's arm.
 
-### [High Res Local Maps](https://www.nexusmods.com/newvegas/mods/77963)
-
-Sharper, clearer local maps.
-
 ### [High Resolution Bloom](https://www.nexusmods.com/newvegas/mods/77933)
 
 Increases bloom precision, reducing flicker.


### PR DESCRIPTION
It's just inconsistent that Simple Maps (World Map) is in UI & HUD, while High Res Local Maps mod (Local Map) is in Visuals.

Also thought about moving **High Res Screens** mod as well, since people most often see it's effect on Pip-Boy, but it's kinda debatable so whatever.