### PR TITLE
Remove deprecated caution hint about MAPMO at ui.md

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -280,13 +280,6 @@ Adds a bunch of features to the Main and Pause menus. Fully customizable.
 - Optional File - Extras - Stewie's Tweaks Sorting Icons Replacer
 - Main File - [MAPMO Custom INI](https://www.nexusmods.com/newvegas/mods/79005?tab=files&file_id=1000121589&nmm=1)
 
-:::caution
-
-This mod will hide the **Mod Configuration Menu** button in the pause menu!
-You can access it with the **M** key.
-
-:::
-
 ### [B42 Notify - Corner Messages Overhaul](https://www.nexusmods.com/newvegas/mods/80085)
 
 Notifications!


### PR DESCRIPTION
Since there is now a custom config that doesn't hide menu buttons, this caution block seems to be irrelevant now