### PR TITLE
ySI Colorful Icon Fix changed name into ySI Colorful Icon Support

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -219,7 +219,7 @@ Uses yUI features to add many custom icons and advanced sorting logic to improve
 
 - Main File - ySI - Sorting Icons
 - Main File - [Colorful Inventory Ycons](https://www.nexusmods.com/newvegas/mods/78674)
-- Main File - [ySI - Colorful Icons Fix](https://www.nexusmods.com/newvegas/mods/85075)
+- Main File - [ySI - Colorful Icons Support](https://www.nexusmods.com/newvegas/mods/85075) (Ignore the Optional Files)
 - Main File - [ySI - Pick Up Prompts](https://www.nexusmods.com/newvegas/mods/85117)
 - Main File - [ySI - Assorted Fixes](https://www.nexusmods.com/newvegas/mods/86715?tab=files)
 - Optional File - [Exit Categories with Tab](https://www.nexusmods.com/newvegas/mods/86715?tab=files)


### PR DESCRIPTION
THe mod changed named and added some optional files that I suggests it would be explaind that they should be ignored.