### PR TITLE
Update ambience.md

### DIFF
--- a/docs/ambience.md
+++ b/docs/ambience.md
@@ -325,10 +325,15 @@ Modernized ambient soundscape with an object based directional sound system. Est
 
 #### Installation:
 
-- Main File - ATMOS Ambient Sound Overhaul - WAV version
+- Main File - ATMOS Ambience Overhaul - Master - Hi-Fi
+- Optional File - ATMOS Ambience Overhaul - Complementary Pack
 - Main File - [ATMOS NV - TTW Patch](https://www.nexusmods.com/newvegas/mods/79005?tab=files&file_id=1000130990&nmm=1)
 - Main File - [ATMOS NV - FPGE Patch](https://www.nexusmods.com/newvegas/mods/79005?tab=files&file_id=1000130991&nmm=1)
 - Main File - [ATMOS - ExRB Patch](https://www.nexusmods.com/newvegas/mods/79005?tab=files&file_id=1000137728&nmm=1)
+
+:::important
+The Complementary Pack contains an .esp file that is necessary for several other mods to function. **You cannot skip this file and expect your game to run.**
+:::
 
 ### [PhySFX](https://www.nexusmods.com/newvegas/mods/87832)
 


### PR DESCRIPTION
Added line requiring Complementary Pack from ATMOS Ambience Overhaul. Since the mod switched the Main File .esp to a .esm, several other plugins can't find the correct file to reference and will prevent the game from running.