### PR TITLE
Fix typo in separator name in ambience.md

### DIFF
--- a/docs/ambience.md
+++ b/docs/ambience.md
@@ -8,7 +8,7 @@ import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
 #### Separator:
 
 - Right-click the empty space in the left pane of MO2 and select **Create separator**.
-- Name the separator **Aesthetics & Ambience **.
+- Name the separator **Aesthetics & Ambience**.
 
 :::tip Why the small selection of texture, lighting, animation, and audio mods?
 Many of these mods are out of the scope of this guide, and as such we have only included those that we feel are critical or highly impactful. For an extensive guide on these types of mods, check out [SALVO 2](https://www.nexusmods.com/newvegas/mods/95649). Support for SALVO 2 is provided on [The Wasteland Supplemental](https://discord.gg/JcbZGDeMmC).


### PR DESCRIPTION
<img width="654" height="219" alt="image" src="https://github.com/user-attachments/assets/11ccbfce-d5a5-4275-b68c-f29523b8a87a" />