### PR TITLE
Remove docusaurus-plugin-image-zoom from dependencies

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -15,8 +15,6 @@ const config = {
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
 
-  plugins: ["docusaurus-plugin-image-zoom"],
-
   i18n: {
     defaultLocale: "en",
     locales: ["en"],
@@ -56,16 +54,6 @@ const config = {
         apiKey: "a62240650a1665512559c9fd6006d035",
         indexName: "wastelandsurvivalguide",
         contextualSearch: false,
-      },
-      // Image zoom plugin
-      zoom: {
-        selector: ".markdown :not(em) > img",
-        background: {
-          light: "rgba(0,0,0,0.3)",
-          dark: "rgba(0,0,0,0.5)",
-        },
-        // options you can specify via https://github.com/francoischalifour/medium-zoom#usage
-        config: {},
       },
       colorMode: {
         defaultMode: "dark",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@mui/icons-material": "^5.11.11",
         "@mui/material": "^5.11.12",
         "clsx": "^1.2.1",
-        "docusaurus-plugin-image-zoom": "^3.0.1",
         "medium-zoom": "^1.0.8",
         "prism-react-renderer": "^2.4.1",
         "react": "^18.0.0",
@@ -8295,19 +8294,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/docusaurus-plugin-image-zoom": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/docusaurus-plugin-image-zoom/-/docusaurus-plugin-image-zoom-3.0.1.tgz",
-      "integrity": "sha512-mQrqA99VpoMQJNbi02qkWAMVNC4+kwc6zLLMNzraHAJlwn+HrlUmZSEDcTwgn+H4herYNxHKxveE2WsYy73eGw==",
-      "license": "MIT",
-      "dependencies": {
-        "medium-zoom": "^1.1.0",
-        "validate-peer-dependencies": "^2.2.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/theme-classic": ">=3.0.0"
-      }
-    },
     "node_modules/dom-converter": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
@@ -13927,27 +13913,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
-    "node_modules/path-root": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
-      "integrity": "sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==",
-      "license": "MIT",
-      "dependencies": {
-        "path-root-regex": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-root-regex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
-      "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-to-regexp": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
@@ -16328,18 +16293,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/resolve-package-path": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
-      "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
-      "license": "MIT",
-      "dependencies": {
-        "path-root": "^0.1.1"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/resolve-pathname": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
@@ -18034,19 +17987,6 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/validate-peer-dependencies": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/validate-peer-dependencies/-/validate-peer-dependencies-2.2.0.tgz",
-      "integrity": "sha512-8X1OWlERjiUY6P6tdeU9E0EwO8RA3bahoOVG7ulOZT5MqgNDUO/BQoVjYiHPcNe+v8glsboZRIw9iToMAA2zAA==",
-      "license": "MIT",
-      "dependencies": {
-        "resolve-package-path": "^4.0.3",
-        "semver": "^7.3.8"
-      },
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/value-equal": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@mui/icons-material": "^5.11.11",
     "@mui/material": "^5.11.12",
     "clsx": "^1.2.1",
-    "docusaurus-plugin-image-zoom": "^3.0.1",
     "medium-zoom": "^1.0.8",
     "prism-react-renderer": "^2.4.1",
     "react": "^18.0.0",


### PR DESCRIPTION
Unnecessary plugin removed. There are only two “visible” images in finish.md, which are perfectly understandable; plus it's not really a zoom—it just fades in and centers the image.